### PR TITLE
Rename ambiguous port to source

### DIFF
--- a/include/cashmere/broker.h
+++ b/include/cashmere/broker.h
@@ -37,24 +37,24 @@ public:
 
   virtual Clock clock() const override;
   virtual IdClockMap versions() const override;
-  virtual SourcesMap sources(Port sender = 0) const override;
-  virtual Clock insert(const Entry& data, Port sender = 0) override;
+  virtual SourcesMap sources(Source sender = 0) const override;
+  virtual Clock insert(const Entry& data, Source sender = 0) override;
   virtual EntryList
-  query(const Clock& from = {}, Port sender = 0) const override;
+  query(const Clock& from = {}, Source sender = 0) const override;
 
-  Port disconnect(Port port);
-  virtual bool refresh(const Connection& conn, Port port) override;
-  virtual std::set<Port> connectedPorts() const;
+  Source disconnect(Source source);
+  virtual bool refresh(const Connection& conn, Source source) override;
+  virtual std::set<Source> connectedPorts() const;
 
   virtual BrokerBasePtr ptr();
   virtual BrokerStub stub() override;
 
   Connection connect(Connection conn) override;
 
-  Clock relay(const Data& entry, Port sender) override;
+  Clock relay(const Data& entry, Source sender) override;
 
 private:
-  void refreshConnections(Port ignore = 0);
+  void refreshConnections(Source ignore = 0);
   void setClock(const Clock& clock);
 
   std::vector<Connection> _connections;

--- a/include/cashmere/brokerbase.h
+++ b/include/cashmere/brokerbase.h
@@ -36,7 +36,7 @@ struct CASHMERE_EXPORT ConnectionInfo
 
 using IdConnectionInfoMap = std::map<Id, ConnectionInfo>;
 
-using SourcesMap = std::map<Port, IdConnectionInfoMap>;
+using SourcesMap = std::map<Source, IdConnectionInfoMap>;
 
 class BrokerBase;
 using BrokerBasePtr = std::shared_ptr<BrokerBase>;
@@ -76,7 +76,7 @@ private:
 
 struct CASHMERE_EXPORT ConnectionData
 {
-  Port port = 0;
+  Source source = 0;
   Clock version = {};
   IdConnectionInfoMap sources = {};
   bool operator==(const ConnectionData& other) const;
@@ -96,7 +96,7 @@ public:
   Connection(BrokerStub stub);
   Connection(BrokerStub stub, ConnectionData data);
   Connection(
-    BrokerStub stub, Port port, Clock version, IdConnectionInfoMap provides
+    BrokerStub stub, Source source, Clock version, IdConnectionInfoMap provides
   );
 
   virtual ~Connection();
@@ -110,7 +110,7 @@ public:
   bool active() const;
   bool refresh(const Connection& conn) const;
 
-  Port& port() const;
+  Source& source() const;
   Clock& version(Origin origin = Origin::Cache) const;
   IdConnectionInfoMap& provides(Origin origin = Origin::Cache) const;
   Clock relay(const Data& entry) const;
@@ -137,15 +137,15 @@ public:
   virtual ~BrokerBase();
 
   virtual Connection connect(Connection conn) = 0;
-  virtual bool refresh(const Connection& conn, Port sender) = 0;
-  virtual Clock insert(const Entry& data, Port sender = 0) = 0;
-  virtual Clock insert(const EntryList& entries, Port sender = 0);
+  virtual bool refresh(const Connection& conn, Source sender) = 0;
+  virtual Clock insert(const Entry& data, Source sender = 0) = 0;
+  virtual Clock insert(const EntryList& entries, Source sender = 0);
 
-  virtual EntryList query(const Clock& from = {}, Port sender = 0) const = 0;
+  virtual EntryList query(const Clock& from = {}, Source sender = 0) const = 0;
   virtual Clock clock() const = 0;
   virtual IdClockMap versions() const = 0;
-  virtual SourcesMap sources(Port sender = 0) const = 0;
-  virtual Clock relay(const Data& entry, Port sender) = 0;
+  virtual SourcesMap sources(Source sender = 0) const = 0;
+  virtual Clock relay(const Data& entry, Source sender) = 0;
   virtual BrokerStub stub() = 0;
 };
 

--- a/include/cashmere/brokergrpcclient.h
+++ b/include/cashmere/brokergrpcclient.h
@@ -33,15 +33,15 @@ public:
   ~BrokerGrpcClient();
   virtual Clock clock() const override;
   virtual IdClockMap versions() const override;
-  virtual SourcesMap sources(Port sender = 0) const override;
-  virtual Clock insert(const Entry& data, Port sender = 0) override;
+  virtual SourcesMap sources(Source sender = 0) const override;
+  virtual Clock insert(const Entry& data, Source sender = 0) override;
   virtual EntryList
-  query(const Clock& from = {}, Port sender = 0) const override;
+  query(const Clock& from = {}, Source sender = 0) const override;
 
   virtual Connection connect(Connection conn) override;
-  virtual bool refresh(const Connection& conn, Port sender) override;
+  virtual bool refresh(const Connection& conn, Source sender) override;
   virtual BrokerStub stub() override;
-  virtual Clock relay(const Data& entry, Port sender) override;
+  virtual Clock relay(const Data& entry, Source sender) override;
 
 private:
   std::unique_ptr<BrokerGrpcStub> _stub;

--- a/include/cashmere/cashmere.h
+++ b/include/cashmere/cashmere.h
@@ -25,7 +25,7 @@ namespace Cashmere
 using Amount = int64_t;
 using Id = uint64_t;
 using Time = uint64_t;
-using Port = uint32_t;
+using Source = uint32_t;
 
 using IdSet = std::set<Id>;
 }

--- a/include/cashmere/journalbase.h
+++ b/include/cashmere/journalbase.h
@@ -36,11 +36,11 @@ public:
   virtual bool save(const Entry& entry) = 0;
   virtual Data entry(Clock time) const = 0;
   virtual EntryList entries() const = 0;
-  SourcesMap sources(Port sender = 0) const override;
+  SourcesMap sources(Source sender = 0) const override;
 
-  Clock insert(const Entry& data, Port source = 0) override;
-  EntryList query(const Clock& from = {}, Port source = 0) const override;
-  virtual Clock relay(const Data& data, Port sender) override
+  Clock insert(const Entry& data, Source source = 0) override;
+  EntryList query(const Clock& from = {}, Source source = 0) const override;
+  virtual Clock relay(const Data& data, Source sender) override
   {
     if (data.id == 0) {
       return Broker::relay({_id, data.value, data.alters}, sender);

--- a/proto/cashmere.proto
+++ b/proto/cashmere.proto
@@ -46,7 +46,7 @@ message BrokerData {
 
 message ConnectionRequest {
   BrokerData broker = 1;
-  uint32 port = 2;
+  uint32 source = 2;
   map<fixed64, uint64> version = 3;
   map<fixed64, ConnectionInfo> sources = 4;
 }
@@ -62,14 +62,14 @@ message QueryRequest {
 }
 
 message ConnectionResponse {
-  uint32 port = 1;
+  uint32 source = 1;
   map<fixed64, uint64> version = 2;
   map<fixed64, ConnectionInfo> sources = 3;
 }
 
 message RefreshRequest {
   uint32 sender = 1;
-  uint32 port = 2;
+  uint32 source = 2;
   map<fixed64, uint64> version = 3;
   map<fixed64, ConnectionInfo> sources = 4;
 }

--- a/src/brokergrpc.cpp
+++ b/src/brokergrpc.cpp
@@ -100,23 +100,23 @@ BrokerGrpc::Impl::Impl()
 )
 {
   auto stub = Utils::BrokerStubFrom(request->broker());
-  if (request->port() == 0) {
+  if (request->source() == 0) {
     const auto conn = broker()->connect(stub);
-    response->set_port(conn.port());
+    response->set_source(conn.source());
   } else {
     const IdConnectionInfoMap sources = Utils::SourcesFrom(request->sources());
     const Clock version = Utils::ClockFrom(request->version());
 
     lg::info(
-      "BrokerGrpc: Connection request from: {}, port: {}, version: {}",
-      request->broker().url(), request->port(), version.str()
+      "BrokerGrpc: Connection request from: {}, source: {}, version: {}",
+      request->broker().url(), request->source(), version.str()
     );
 
-    Connection conn{stub, request->port(), version, sources};
+    Connection conn{stub, request->source(), version, sources};
 
     Connection out = broker()->connect(conn);
 
-    response->set_port(out.port());
+    response->set_source(out.source());
     Utils::SetClock(response->mutable_version(), out.version());
     Utils::SetSources(response->mutable_sources(), out.provides());
   }
@@ -145,7 +145,7 @@ BrokerGrpc::Impl::Impl()
   const Grpc::InsertRequest* request, Grpc::InsertResponse* response
 )
 {
-  Port sender = request->sender();
+  Source sender = request->sender();
   Entry entry = Utils::EntryFrom(request->entry());
 
   lg::info(
@@ -167,7 +167,7 @@ BrokerGrpc::Impl::Impl()
 )
 {
   Connection conn;
-  conn.port() = request->port();
+  conn.source() = request->source();
   conn.version() = Utils::ClockFrom(request->version());
   conn.provides() = Utils::SourcesFrom(request->sources());
   broker()->refresh(conn, request->sender());

--- a/src/brokergrpcclient.cpp
+++ b/src/brokergrpcclient.cpp
@@ -35,17 +35,17 @@ IdClockMap BrokerGrpcClient::versions() const
   return _stub->versions();
 }
 
-SourcesMap BrokerGrpcClient::sources(Port sender) const
+SourcesMap BrokerGrpcClient::sources(Source sender) const
 {
   return _stub->sources(sender);
 }
 
-Clock BrokerGrpcClient::insert(const Entry& data, Port sender)
+Clock BrokerGrpcClient::insert(const Entry& data, Source sender)
 {
   return _stub->insert(data, sender);
 }
 
-EntryList BrokerGrpcClient::query(const Clock& from, Port sender) const
+EntryList BrokerGrpcClient::query(const Clock& from, Source sender) const
 {
   return _stub->query(from, sender);
 }
@@ -55,12 +55,12 @@ Connection BrokerGrpcClient::connect(Connection conn)
   return _stub->connect(conn);
 }
 
-bool BrokerGrpcClient::refresh(const Connection& conn, Port sender)
+bool BrokerGrpcClient::refresh(const Connection& conn, Source sender)
 {
   return _stub->refresh(conn, sender);
 }
 
-Clock BrokerGrpcClient::relay(const Data& entry, Port sender)
+Clock BrokerGrpcClient::relay(const Data& entry, Source sender)
 {
   return _stub->relay(entry, sender);
 }

--- a/src/brokergrpcstub.cpp
+++ b/src/brokergrpcstub.cpp
@@ -67,12 +67,12 @@ IdClockMap BrokerGrpcStub::versions() const
   return {};
 }
 
-SourcesMap BrokerGrpcStub::sources([[maybe_unused]] Port sender) const
+SourcesMap BrokerGrpcStub::sources([[maybe_unused]] Source sender) const
 {
   return {};
 }
 
-Clock BrokerGrpcStub::insert(const Entry& data, Port sender)
+Clock BrokerGrpcStub::insert(const Entry& data, Source sender)
 {
   Grpc::InsertRequest request;
   request.set_sender(sender);
@@ -87,7 +87,7 @@ Clock BrokerGrpcStub::insert(const Entry& data, Port sender)
   return {};
 }
 
-EntryList BrokerGrpcStub::query(const Clock& from, Port sender) const
+EntryList BrokerGrpcStub::query(const Clock& from, Source sender) const
 {
   ::grpc::ClientContext context;
   Grpc::QueryRequest request;
@@ -113,7 +113,7 @@ Connection BrokerGrpcStub::connect(Connection conn)
   ::grpc::ClientContext context;
 
   Grpc::ConnectionRequest request;
-  request.set_port(conn.port());
+  request.set_source(conn.source());
   Utils::SetClock(request.mutable_version(), conn.version());
 
   request.mutable_broker()->set_url(conn.stub().url());
@@ -125,7 +125,7 @@ Connection BrokerGrpcStub::connect(Connection conn)
   auto status = _stub->Connect(&context, request, &response);
   if (status.ok()) {
     Clock clock = Utils::ClockFrom(response.version());
-    return Connection{BrokerStub{_url}, response.port(), clock, {}};
+    return Connection{BrokerStub{_url}, response.source(), clock, {}};
   } else {
     lg::error(
       "BrokerGrpcStub: error {} connecting to {}",
@@ -135,11 +135,11 @@ Connection BrokerGrpcStub::connect(Connection conn)
   return Connection();
 }
 
-bool BrokerGrpcStub::refresh(const Connection& conn, Port sender)
+bool BrokerGrpcStub::refresh(const Connection& conn, Source sender)
 {
   Grpc::RefreshRequest request;
   request.set_sender(sender);
-  request.set_port(conn.port());
+  request.set_source(conn.source());
 
   Utils::SetClock(request.mutable_version(), conn.version());
   Utils::SetSources(request.mutable_sources(), conn.provides());
@@ -153,7 +153,7 @@ bool BrokerGrpcStub::refresh(const Connection& conn, Port sender)
   return {};
 }
 
-Clock BrokerGrpcStub::relay(const Data& entry, Port sender)
+Clock BrokerGrpcStub::relay(const Data& entry, Source sender)
 {
   ::grpc::ClientContext context;
   Grpc::RelayInsertRequest request;

--- a/src/brokergrpcstub.h
+++ b/src/brokergrpcstub.h
@@ -34,15 +34,15 @@ public:
   explicit BrokerGrpcStub(std::unique_ptr<Grpc::Broker::StubInterface>&& stub);
   virtual Clock clock() const override;
   virtual IdClockMap versions() const override;
-  virtual SourcesMap sources(Port sender = 0) const override;
-  virtual Clock insert(const Entry& data, Port sender = 0) override;
+  virtual SourcesMap sources(Source sender = 0) const override;
+  virtual Clock insert(const Entry& data, Source sender = 0) override;
   virtual EntryList
-  query(const Clock& from = {}, Port sender = 0) const override;
+  query(const Clock& from = {}, Source sender = 0) const override;
 
   virtual Connection connect(Connection conn) override;
-  virtual bool refresh(const Connection& conn, Port sender) override;
+  virtual bool refresh(const Connection& conn, Source sender) override;
   virtual BrokerStub stub() override;
-  virtual Clock relay(const Data& entry, Port sender) override;
+  virtual Clock relay(const Data& entry, Source sender) override;
 
 private:
   std::string _url;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -70,7 +70,7 @@ Command Command::Read(std::istream& in)
       break;
     case Type::Disconnect:
       in >> argument;
-      command.port = std::stoi(argument);
+      command.source = std::stoi(argument);
       break;
     default:
       break;

--- a/src/command.h
+++ b/src/command.h
@@ -40,7 +40,7 @@ struct Command
 
   Type type = Type::Invalid;
   std::string url;
-  Cashmere::Port port;
+  Cashmere::Source source;
   Cashmere::Data data = {};
 
 private:

--- a/src/journalbase.cpp
+++ b/src/journalbase.cpp
@@ -56,13 +56,13 @@ bool JournalBase::append(const Data& entry)
   return insert({clock().tick(entry.id), entry}).valid();
 }
 
-Clock JournalBase::insert(const Entry& data, Port port)
+Clock JournalBase::insert(const Entry& data, Source source)
 {
   if (!data.clock.isNext(clock(), data.entry.id)) {
     return Clock{{0, 0}};
   }
   if (save(data)) {
-    return Broker::insert(data, port);
+    return Broker::insert(data, source);
   }
   return Clock{{0, 0}};
 }
@@ -82,7 +82,7 @@ bool JournalBase::contains(const Clock& time) const
   return entry(time).valid();
 }
 
-EntryList JournalBase::query(const Clock& from, Port) const
+EntryList JournalBase::query(const Clock& from, Source) const
 {
   EntryList list;
   for (const auto& [clock, entry] : entries()) {
@@ -93,7 +93,7 @@ EntryList JournalBase::query(const Clock& from, Port) const
   return list;
 }
 
-SourcesMap JournalBase::sources(Port sender) const
+SourcesMap JournalBase::sources(Source sender) const
 {
   auto out = Broker::sources(sender);
   out[0] = {{_id, {0, clock()}}};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
 
 void RunCommand(const Options& options)
 {
-  auto stub = BrokerGrpcClient(options.hostname, options.port);
+  auto stub = BrokerGrpcClient(options.hostname, options.source);
   switch (options.command.type) {
     case Command::Type::Invalid:
       break;
@@ -114,7 +114,7 @@ void RunCommand(const Options& options)
 void RunService(const Options& options)
 {
   auto tempDir = TempDir();
-  auto broker = std::make_shared<BrokerGrpc>(options.hostname, options.port);
+  auto broker = std::make_shared<BrokerGrpc>(options.hostname, options.source);
   auto journal = std::make_shared<JournalFile>(
     options.id, options.dbPath.empty() ? tempDir.directory : options.dbPath
   );
@@ -122,7 +122,7 @@ void RunService(const Options& options)
   journal->connect(BrokerStub{broker});
 
   lg::info(
-    "Journal {:x}, port: {}, path: {}", options.id, options.port,
+    "Journal {:x}, port: {}, path: {}", options.id, options.source,
     tempDir.directory
   );
 
@@ -142,12 +142,12 @@ void RunService(const Options& options)
       {
         const auto conn = broker->connect(BrokerStub(command.url));
         if (!conn.valid()) {
-          std::println("{}: failed {}", command.name(), options.port);
+          std::println("{}: failed {}", command.name(), options.source);
         }
         break;
       }
       case Command::Type::Disconnect:
-        broker->disconnect(command.port);
+        broker->disconnect(command.source);
         break;
       case Command::Type::Append:
         command.data.id = journal->id();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -42,7 +42,7 @@ Options::Options(int argc, char* argv[])
         break;
       case 'p':
         try {
-          port = std::stoi(optarg);
+          source = std::stoi(optarg);
         } catch (const std::exception&) {
           _error.status = Status::InvalidOptionArgument;
         }
@@ -90,7 +90,7 @@ Options::Error Options::error() const
 
 bool operator==(const Options& a, const Options& b)
 {
-  return a.id == b.id && a.port == b.port && a.hostname == b.hostname &&
+  return a.id == b.id && a.source == b.source && a.hostname == b.hostname &&
          a.service == b.service && a.command == b.command;
 }
 

--- a/src/options.h
+++ b/src/options.h
@@ -45,7 +45,7 @@ struct Options
   bool ok() const;
 
   Cashmere::Id id = 0;
-  Cashmere::Port port = 54321;
+  Cashmere::Source source = 54321;
   std::string hostname = "0.0.0.0";
   bool service = false;
   std::string dbPath = "";

--- a/tests/brokermock.h
+++ b/tests/brokermock.h
@@ -27,18 +27,22 @@ namespace Cashmere
 class BrokerMock : public BrokerBase
 {
 public:
-  MOCK_METHOD(Clock, insert, (const Entry& data, Port sender), (override));
-  MOCK_METHOD(Clock, insert, (const EntryList& data, Port sender), (override));
+  MOCK_METHOD(Clock, insert, (const Entry& data, Source sender), (override));
   MOCK_METHOD(
-    EntryList, query, (const Clock& from, Port sender), (const, override)
+    Clock, insert, (const EntryList& data, Source sender), (override)
   );
-  MOCK_METHOD(SourcesMap, sources, (Port to), (const, override));
+  MOCK_METHOD(
+    EntryList, query, (const Clock& from, Source sender), (const, override)
+  );
+  MOCK_METHOD(SourcesMap, sources, (Source to), (const, override));
   MOCK_METHOD(IdClockMap, versions, (), (const, override));
   MOCK_METHOD(Clock, clock, (), (const, override));
   MOCK_METHOD(Connection, connect, (Connection conn), (override));
-  MOCK_METHOD(bool, refresh, (const Connection& data, Port port), (override));
+  MOCK_METHOD(
+    bool, refresh, (const Connection& data, Source source), (override)
+  );
   MOCK_METHOD(BrokerStub, stub, (), (override));
-  MOCK_METHOD(Clock, relay, (const Data& data, Port port), (override));
+  MOCK_METHOD(Clock, relay, (const Data& data, Source source), (override));
 };
 
 }

--- a/tests/test_broker.cpp
+++ b/tests/test_broker.cpp
@@ -27,7 +27,7 @@ TEST(Broker, ConnectIgnoresNullptr)
 {
   auto broker = std::make_shared<Broker>();
   const auto conn = broker->connect(Connection{});
-  ASSERT_EQ(conn.port(), -1);
+  ASSERT_EQ(conn.source(), -1);
 }
 
 TEST(Broker, DisconnectedBrokerHasEmptyClock)
@@ -45,7 +45,7 @@ TEST(Broker, DisconnectedBrokerHasEmptyVersions)
 TEST(Broker, StartsWithNoConnections)
 {
   BrokerPtr broker = std::make_shared<Broker>();
-  EXPECT_EQ(broker->connectedPorts(), std::set<Port>{});
+  EXPECT_EQ(broker->connectedPorts(), std::set<Source>{});
 }
 
 TEST(Broker, SuccessfulConnectionReturnsValidConnection)
@@ -75,7 +75,7 @@ TEST(Broker, BrokerFirstConnectionUsesPortOne)
     }));
 
   hub->connect(BrokerStub{aa});
-  EXPECT_EQ(hub->connectedPorts(), std::set<Port>{1});
+  EXPECT_EQ(hub->connectedPorts(), std::set<Source>{1});
 }
 
 TEST(Broker, BrokerForwardsInserts)
@@ -110,9 +110,9 @@ TEST(Broker, BrokerOnlyForwardsInsertsToPortsDifferentOfTheSender)
 
   const auto conn = hub->connect(BrokerStub{aa});
 
-  EXPECT_EQ(conn.port(), 1);
+  EXPECT_EQ(conn.source(), 1);
 
-  hub->insert(entry, conn.port());
+  hub->insert(entry, conn.source());
 }
 
 TEST(Broker, BrokeHubConnectionsAreFullDuplex)
@@ -131,11 +131,11 @@ TEST(Broker, BrokeHubConnectionsAreFullDuplex)
   const auto hub1Conn = hub0->connect(BrokerStub{hub1});
   const auto aaConn = hub0->connect(BrokerStub{aa});
 
-  EXPECT_EQ(hub1Conn.port(), 1);
-  EXPECT_EQ(aaConn.port(), 2);
+  EXPECT_EQ(hub1Conn.source(), 1);
+  EXPECT_EQ(aaConn.source(), 2);
 
-  EXPECT_EQ(hub0->connectedPorts(), std::set<Port>({1, 2}));
-  EXPECT_EQ(hub1->connectedPorts(), std::set<Port>{1});
+  EXPECT_EQ(hub0->connectedPorts(), std::set<Source>({1, 2}));
+  EXPECT_EQ(hub1->connectedPorts(), std::set<Source>{1});
 
   hub1->insert(entry, 0);
 }
@@ -186,8 +186,8 @@ TEST(Broker, VersionsArePreservedAfterDisconnection)
     .WillOnce(Return(EntryList{{aaClock, Data{0xAA, 10, {}}}}));
 
   hub->connect(BrokerStub{aa});
-  const Port port = hub->disconnect(1);
-  EXPECT_EQ(port, 1);
+  const Source source = hub->disconnect(1);
+  EXPECT_EQ(source, 1);
 
   EXPECT_EQ(hub->sources(), SourcesMap{});
   EXPECT_EQ(hub->clock(), aaClock);

--- a/tests/test_brokergrpcstub.cpp
+++ b/tests/test_brokergrpcstub.cpp
@@ -25,7 +25,7 @@
 using namespace ::Cashmere;
 using namespace ::testing;
 
-constexpr int32_t kPort = 10;
+constexpr int32_t kSource = 10;
 
 using StubInterfacePtr = std::unique_ptr<Grpc::Broker::StubInterface>;
 
@@ -36,7 +36,7 @@ TEST(BrokerGrpcStub, StartsConnectionsUsingGrpcStub)
   auto stub = std::make_unique<Grpc::MockBrokerStub>();
 
   Grpc::ConnectionResponse resp;
-  resp.set_port(kPort);
+  resp.set_source(kSource);
   (*resp.mutable_version())[0xBB] = 1;
 
   EXPECT_CALL(*stub, Connect(_, _, _))
@@ -52,7 +52,8 @@ TEST(BrokerGrpcStub, StartsConnectionsUsingGrpcStub)
   EXPECT_CALL(
     *stub,
     Query(
-      _, ResultOf([](Grpc::QueryRequest in) { return in.sender(); }, Eq(kPort)),
+      _,
+      ResultOf([](Grpc::QueryRequest in) { return in.sender(); }, Eq(kSource)),
       _
     )
   )
@@ -75,7 +76,7 @@ TEST(BrokerGrpcStub, InsertIsCalledPassingTheCorrectPort)
   auto stub = std::make_unique<Grpc::MockBrokerStub>();
 
   Grpc::ConnectionResponse resp;
-  resp.set_port(kPort);
+  resp.set_source(kSource);
 
   EXPECT_CALL(*stub, Connect(_, _, _))
     .Times(1)
@@ -88,7 +89,8 @@ TEST(BrokerGrpcStub, InsertIsCalledPassingTheCorrectPort)
     *stub,
     Insert(
       _,
-      ResultOf([](Grpc::InsertRequest in) { return in.sender(); }, Eq(kPort)), _
+      ResultOf([](Grpc::InsertRequest in) { return in.sender(); }, Eq(kSource)),
+      _
     )
   )
     .Times(1)
@@ -129,7 +131,7 @@ TEST(BrokerGrpcStub, RefreshIsCalledOnDisconnect)
   auto stub = std::make_unique<Grpc::MockBrokerStub>();
 
   Grpc::ConnectionResponse resp;
-  resp.set_port(10);
+  resp.set_source(10);
 
   EXPECT_CALL(*stub, Connect(_, _, _))
     .Times(1)
@@ -157,19 +159,20 @@ TEST(BrokerGrpcStub, RefreshIsCalledWithSender)
   auto stub = std::make_unique<Grpc::MockBrokerStub>();
 
   Grpc::ConnectionResponse resp;
-  resp.set_port(kPort);
+  resp.set_source(kSource);
 
   EXPECT_CALL(*stub, Connect(_, _, _))
     .Times(1)
     .WillOnce(DoAll(SetArgPointee<2>(resp), Return(grpc::Status::OK)));
 
   EXPECT_CALL(
-    *stub,
-    Refresh(
-      _,
-      ResultOf([](Grpc::RefreshRequest in) { return in.sender(); }, Eq(kPort)),
-      _
-    )
+    *stub, Refresh(
+             _,
+             ResultOf(
+               [](Grpc::RefreshRequest in) { return in.sender(); }, Eq(kSource)
+             ),
+             _
+           )
   )
     .Times(1)
     .WillOnce(Return(grpc::Status::OK));

--- a/tests/test_options.cpp
+++ b/tests/test_options.cpp
@@ -73,7 +73,7 @@ TEST(OptionsParse, ParsePort)
 {
   Args args({"anyname", "-p", "1024", "-s"});
   Options options(args.argc, args.argv);
-  ASSERT_EQ(options.port, 1024);
+  ASSERT_EQ(options.source, 1024);
   EXPECT_TRUE(options.ok());
 }
 


### PR DESCRIPTION
To avoid confusion with the term 'port', which is widely used in networking, we will use the term 'source'. Brokers have connections and each connection is represented as a source.